### PR TITLE
Msp packet sending

### DIFF
--- a/src/MspCommands.hpp
+++ b/src/MspCommands.hpp
@@ -12,15 +12,21 @@ namespace FcComms
 {
     struct MSP_IDENT
     {
+        // Default constructor an destructor
+        MSP_IDENT() = default;
+        ~MSP_IDENT() = default;
+
         // Don't allow the copy constructor or assignment.
         MSP_IDENT(const MSP_IDENT& rhs) = delete;
         MSP_IDENT& operator=(const MSP_IDENT& rhs) = delete;
 
         static const uint8_t message_id{100};
         static const uint8_t data_length{0};
-        static const bool response{true};
+        static const bool has_response{true};
 
-        uint8_t data[FcCommsMspConf::kMspMaxDataLength];
+        static constexpr char const * const string_name{"MSP_IDENT"};
+
+        const uint8_t send[FcCommsMspConf::kMspMaxDataLength]={};
 
         uint8_t response[FcCommsMspConf::kMspMaxDataLength];
     };

--- a/src/MspCommands.hpp
+++ b/src/MspCommands.hpp
@@ -1,0 +1,29 @@
+#ifndef MSP_COMMANDS_HPP
+#define MSP_COMMANDS_HPP
+
+////////////////////////////////////////////////////////////////////////////
+//
+// Msp command packets
+//
+////////////////////////////////////////////////////////////////////////////
+#include "MspConf.hpp"
+
+namespace FcComms
+{
+    struct MSP_IDENT
+    {
+        // Don't allow the copy constructor or assignment.
+        MSP_IDENT(const MSP_IDENT& rhs) = delete;
+        MSP_IDENT& operator=(const MSP_IDENT& rhs) = delete;
+
+        static const uint8_t message_id{100};
+        static const uint8_t data_length{0};
+        static const bool response{true};
+
+        uint8_t data[FcCommsMspConf::kMspMaxDataLength];
+
+        uint8_t response[FcCommsMspConf::kMspMaxDataLength];
+    };
+}
+
+#endif

--- a/src/MspConf.hpp
+++ b/src/MspConf.hpp
@@ -15,7 +15,7 @@ namespace FcComms
         static const uint32_t kBaudRate{9600};
 
         // Needs space on end to bug in serial package
-        static constexpr const char* kHardwareId = "USB VID:PID=1a86:7523 ";
+        static constexpr char const * const kHardwareId{"USB VID:PID=1a86:7523 "};
 
         // In seconds.
         static constexpr const float kFcSensorsUpdatePeriod{0.2};
@@ -28,6 +28,16 @@ namespace FcComms
 
         // Longest MSP data section
         static const uint8_t kMspMaxDataLength = 127;
+
+        // Length of packet header
+        static const uint8_t kMspHeaderSize = 3;
+
+        // Header for receiving a message
+        static constexpr char const * const kMspReceiveHeader{"$M>"};
+
+        // Header for sending a message
+        static constexpr char const * const kMspSendHeader{"$M<"};
+
     };
 
 }

--- a/src/MspConf.hpp
+++ b/src/MspConf.hpp
@@ -19,7 +19,17 @@ namespace FcComms
 
         // In seconds.
         static constexpr const float kFcSensorsUpdatePeriod{0.2};
+
+        // Non Data MSP packet length in bytes
+        static const uint8_t kMspNonDataLength = 6;
+
+        // Non Data MSP packet length in bytes
+        static const uint8_t kMspPacketDataOffset = 5;
+
+        // Longest MSP data section
+        static const uint8_t kMspMaxDataLength = 127;
     };
+
 }
 
 #endif // End MSP_CONF_HPP

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -15,8 +15,6 @@
 #include "MspCommands.hpp"
 #include "serial/serial.h"
 
-using namespace FcComms;
-
 namespace FcComms
 {
 
@@ -232,8 +230,9 @@ namespace FcComms
             // Now receive
             if(message.has_response)
             {
-                std::string header = fc_serial_->read(FcCommsMspConf::kMspHeaderSize);
-                if(header == FcCommsMspConf::kMspReceiveHeader)
+                std::string header = fc_serial_->read(FcCommsMspConf::kMspHeaderSize);\
+                // Header is of type std::string so we can use this type of comparison
+                if(header != FcCommsMspConf::kMspReceiveHeader)
                 {
                     ROS_ERROR("Invalid message header from FC.");
                     return FcCommsReturns::kReturnError;

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -175,50 +175,50 @@ namespace FcComms
         // Try sending an ident request
         MSP_IDENT ident;
         sendMessage<MSP_IDENT>(ident);
-        uint8_t * const results = ident.response();
+        char * const results = reinterpret_cast<char* const>(ident.response);
         results[8] = '\0';
-        ROS_INFO("%s", ident.response());
-
+        ROS_INFO("%s", ident.response);
         return FcCommsReturns::kReturnOk;
     }
 
+    // Implementation to send a receive a response from the flight controller
+    // Protocol specification here: http://www.stefanocottafavi.com/msp-the-multiwii-serial-protocol/
     template<typename T>
     FcCommsReturns MspFcComms::sendMessage(T& message)
     {
         if(fc_comms_status_ == FcCommsStatus::kConnected)
         {
             // Check length of data section
-            if(message.data_length() > FcCommsMspConf::kMspMaxDataLength)
+            if(message.data_length > FcCommsMspConf::kMspMaxDataLength)
             {
                 ROS_ERROR("FC_Comms data section > kMspMaxDataLength was attempted.");
                 return FcCommsReturns::kReturnError;
             }
 
             // Add the header, data_length, and message code
-            uint8_t packet[FcCommsMspConf::kMspNonDataLength + message.data_length()];
-            uint8_t const * const data = message.data();
-            packet[0] = '$';
-            packet[1] = 'M';
-            packet[2] = '<';
-            packet[3] = message.data_length();
-            packet[4] = message.message_id();
+            uint8_t packet[FcCommsMspConf::kMspNonDataLength + message.data_length];
+
+            std::copy(FcCommsMspConf::kMspSendHeader, FcCommsMspConf::kMspSendHeader + 3, packet);
+            packet[3] = message.data_length;
+            packet[4] = message.message_id;
             
             // Start off checksum calculation
-            uint8_t checksum(message.data_length() ^ message.message_id());
+            uint8_t checksum{message.data_length ^ message.message_id};
 
+            #pragma GCC warning "Convert for loops in this function to some cleaner form of array copy"
             // Copy data into message and finish calculating checksum
-            for(int i = 0; i < message.data_length(); i++)
+            for(int i = 0; i < message.data_length; i++)
             {
-                packet[FcCommsMspConf::kMspPacketDataOffset + i] = data[i];
-                checksum ^= data[i];
+                packet[FcCommsMspConf::kMspPacketDataOffset + i] = message.send[i];
+                checksum ^= message.send[i];
             }
 
             // Add checksum to packet
-            packet[FcCommsMspConf::kMspPacketDataOffset + message.data_length()] = checksum;
+            packet[FcCommsMspConf::kMspPacketDataOffset + message.data_length] = checksum;
 
             try
             {
-                fc_serial_->write(packet, FcCommsMspConf::kMspNonDataLength + message.data_length());
+                fc_serial_->write(packet, FcCommsMspConf::kMspNonDataLength + message.data_length);
             }
             // Catch if there is an error writing
             catch(const std::exception& e)
@@ -228,12 +228,69 @@ namespace FcComms
                 return FcCommsReturns::kReturnError;
             }
 
+            #pragma GCC warning "It would be good to split this off to another function"
             // Now receive
+            if(message.has_response)
+            {
+                std::string header = fc_serial_->read(FcCommsMspConf::kMspHeaderSize);
+                if(header == FcCommsMspConf::kMspReceiveHeader)
+                {
+                    ROS_ERROR("Invalid message header from FC.");
+                    return FcCommsReturns::kReturnError;
+                }
 
+                // Read length of data section
+                uint8_t data_length{0};
+                #pragma GCC warning "TODO check how many bytes were received. Bound data_length."
+                (void)fc_serial_->read(&data_length, 1);
+
+                // Read rest of message
+                // Resulting buffer length is data length + message id length + crc
+                uint8_t message_length_no_header = data_length + 1 + 1;
+                uint8_t buffer[message_length_no_header];
+                #pragma GCC warning "TODO check how many bytes were received."
+                uint8_t message_length_read = fc_serial_->read(&buffer[0], message_length_no_header);
+
+                #pragma GCC warning "TODO Check that the message_ids are the same"
+                // Log errors
+                // Check that the lengths read are correct
+                if(message_length_read != message_length_no_header)
+                {
+                    ROS_ERROR("FC_Comms not all bytes received, expected: %d, got: %d", message_length_no_header, message_length_read);
+                    return FcCommsReturns::kReturnError;
+                }
+
+                // Calculate checksum from received data
+                // Only checksum up to message_length_read_1 to avoid xoring the checksum
+                uint8_t checksum = data_length;
+                for(int i = 0; i < message_length_no_header - 1; i++)
+                {
+                    checksum ^= buffer[i];
+                }
+
+                // Compare checksums
+                if(checksum != buffer[message_length_no_header-1])
+                {
+                    ROS_ERROR("FC_Comms CRC receive error, expected: %x, got: %x", checksum, buffer[message_length_no_header - 1]);
+                    return FcCommsReturns::kReturnError;
+                }
+
+                // Copy output buffer
+                #pragma GCC warning "Replace with more C++ style copy"
+                for(int i = 0; i < data_length; i++)
+                {
+                    // Data Length + header = 2
+                    #pragma GCC warning "TODO remove hardcoded 2"
+                    message.response[i] = buffer[2+i];
+                }
+            }
         }
         else
         {
-            ROS_WARN("Attempted to send FC message without being connected, message id: %d", message.message_id());
+            ROS_WARN("Attempted to send FC message without being connected, message id: %d", message.message_id);
         }
+
+        ROS_INFO("FC_COMMS %s sent/received succesfully", message.string_name);
+        return FcCommsReturns::kReturnOk;
     }
 }


### PR DESCRIPTION
Adds actual MSP protocol implementation. Still needs to be tested on physical hardware, could use some cleanup as per the #pragmas.

It might be a good idea to add methods to interpret the data in a Message classes receive buffer too.
