### PR TITLE
Handle exceptions and incorrect amount of bytes received.

### DIFF
--- a/src/MspConf.hpp
+++ b/src/MspConf.hpp
@@ -14,6 +14,8 @@ namespace FcComms
     {
         static const uint32_t kBaudRate{115200};
 
+        static const uint32_t kSerialTimeoutMs{75};
+
         // Needs space on end to bug in serial package
         static constexpr char const * const kHardwareId{"USB VID:PID=10c4:ea60 SNR=0001"};
 

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -159,6 +159,9 @@ namespace FcComms
             ROS_INFO("FC_Comms Connected to FC");
             fc_comms_status_ = FcCommsStatus::kConnected;
 
+            // Pause to allow the flight controller to come up
+            ros::Duration(2.0).sleep();
+
             return FcCommsReturns::kReturnOk;
         }
         // Catch if there is an error making the connection.
@@ -260,61 +263,73 @@ namespace FcComms
             {
                 ROS_ERROR("FC_Comms error sending MSP packet");
                 ROS_ERROR("Exception: %s", e.what());
+                fc_comms_status_ = FcCommsStatus::kDisconnected;
                 return FcCommsReturns::kReturnError;
             }
 
             #pragma GCC warning "It would be good to split this off to another function"
             
-            // Now receive
-            std::string header = fc_serial_->read(FcCommsMspConf::kMspHeaderSize);\
-            // Header is of type std::string so we can use this type of comparison
-            if(header != FcCommsMspConf::kMspReceiveHeader)
+            try
             {
-                ROS_ERROR("Invalid message header from FC.");
+                // Now receive
+                std::string header = fc_serial_->read(FcCommsMspConf::kMspHeaderSize);\
+                // Header is of type std::string so we can use this type of comparison
+                if(header != FcCommsMspConf::kMspReceiveHeader)
+                {
+                    ROS_ERROR("Invalid message header from FC.");
+                    return FcCommsReturns::kReturnError;
+                }
+
+                // Read length of data section
+                uint8_t data_length{0};
+                #pragma GCC warning "TODO check how many bytes were received. Bound data_length."
+                (void)fc_serial_->read(&data_length, 1);
+
+                // Read rest of message
+                // Resulting buffer length is data length + message id length + crc
+                uint8_t message_length_no_header = data_length + 1 + 1;
+                uint8_t buffer[message_length_no_header];
+                #pragma GCC warning "TODO check how many bytes were received."
+                uint8_t message_length_read = fc_serial_->read(&buffer[0], message_length_no_header);
+
+                if(buffer[0] != packet[4])
+                {
+                    ROS_ERROR("Received packet id does not match the one sent previously");
+                }
+                // Log errors
+                // Check that the lengths read are correct
+                if(message_length_read != message_length_no_header)
+                {
+                    ROS_ERROR("FC_Comms not all bytes received, expected: %d, got: %d", message_length_no_header, message_length_read);
+                    return FcCommsReturns::kReturnError;
+                }
+
+                // Calculate checksum from received data
+                // Only checksum up to message_length_read_1 to avoid xoring the checksum
+                uint8_t crc = data_length;
+                for(int i = 0; i < message_length_no_header - 1; i++)
+                {
+                    crc ^= buffer[i];
+                }
+
+                // Compare checksums
+                if(crc != buffer[message_length_no_header-1])
+                {
+                    ROS_ERROR("FC_Comms CRC receive error, expected: %x, got: %x", crc, buffer[message_length_no_header - 1]);
+                    return FcCommsReturns::kReturnError;
+                }
+
+                // Copy output buffer response to message
+                std::copy(buffer+1, buffer+1+data_length, message.response);
+            }
+            // Catch if there is an error reading
+            catch(const std::exception& e)
+            {
+                ROS_ERROR("FC_Comms error reading MSP packet");
+                ROS_ERROR("Exception: %s", e.what());
+                fc_comms_status_ = FcCommsStatus::kDisconnected;
                 return FcCommsReturns::kReturnError;
             }
-
-            // Read length of data section
-            uint8_t data_length{0};
-            #pragma GCC warning "TODO check how many bytes were received. Bound data_length."
-            (void)fc_serial_->read(&data_length, 1);
-
-            // Read rest of message
-            // Resulting buffer length is data length + message id length + crc
-            uint8_t message_length_no_header = data_length + 1 + 1;
-            uint8_t buffer[message_length_no_header];
-            #pragma GCC warning "TODO check how many bytes were received."
-            uint8_t message_length_read = fc_serial_->read(&buffer[0], message_length_no_header);
-
-            if(buffer[0] != packet[4])
-            {
-                ROS_ERROR("Received packet id does not match the one sent previously");
-            }
-            // Log errors
-            // Check that the lengths read are correct
-            if(message_length_read != message_length_no_header)
-            {
-                ROS_ERROR("FC_Comms not all bytes received, expected: %d, got: %d", message_length_no_header, message_length_read);
-                return FcCommsReturns::kReturnError;
-            }
-
-            // Calculate checksum from received data
-            // Only checksum up to message_length_read_1 to avoid xoring the checksum
-            uint8_t crc = data_length;
-            for(int i = 0; i < message_length_no_header - 1; i++)
-            {
-                crc ^= buffer[i];
-            }
-
-            // Compare checksums
-            if(crc != buffer[message_length_no_header-1])
-            {
-                ROS_ERROR("FC_Comms CRC receive error, expected: %x, got: %x", crc, buffer[message_length_no_header - 1]);
-                return FcCommsReturns::kReturnError;
-            }
-
-            // Copy output buffer response to message
-            std::copy(buffer+1, buffer+1+data_length, message.response);
         }
         else
         {


### PR DESCRIPTION
This correctly handles when the flight controller either goes offline or there is partial/complete serial linkage breakage. The solution is to attempt to attempt reconnection in all cases.
