### PR TITLE
Add ability to request arming of flight controller, should be done by UI

### DIFF
--- a/src/CommonFcComms.hpp
+++ b/src/CommonFcComms.hpp
@@ -65,6 +65,9 @@ namespace FcComms{
         // Subscriber for uav_throttle valuess
         ros::Subscriber uav_throttle_subscriber;
 
+        // Subscriber for uav_arm
+        ros::Subscriber uav_arm_subscriber;
+
     };
 }
 
@@ -91,6 +94,7 @@ FcCommsReturns CommonFcComms<T>::init()
     status_publisher = nh_.advertise<iarc7_msgs::FlightControllerStatus>("fc_status", 50);
     uav_angle_subscriber = nh_.subscribe("uav_angles", 100, &T::sendFcAngles, &flightControlImpl_);
     uav_throttle_subscriber = nh_.subscribe("uav_throttle", 100, &T::sendFcThrottle, &flightControlImpl_);
+    uav_arm_subscriber = nh_.subscribe("uav_arm", 100, &T::sendArmRequest, &flightControlImpl_);
 
     ROS_INFO("FC Comms registered and subscribed to topics");
 

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -62,7 +62,7 @@ namespace FcComms
     void MspFcComms::sendArmRequest(const iarc7_msgs::BoolStamped::ConstPtr& message)
     {
         // Try to arm, Values over 1800 arm the FC
-        translated_rc_values_[4] = (message->arm_request == true) ? 2000 : 1000;
+        translated_rc_values_[4] = (message->data == true) ? 2000 : 1000;
     }
 
     // Send the rc commands to the FC using the member array of rc values.

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -63,6 +63,8 @@ namespace FcComms
     {
         // Try to arm, Values over 1800 arm the FC
         translated_rc_values_[4] = (message->data == true) ? 2000 : 1000;
+        #pragma GCC warning "Handle return"
+        (void)sendRc();
     }
 
     // Send the rc commands to the FC using the member array of rc values.
@@ -72,9 +74,6 @@ namespace FcComms
         msp_rc.packRc(translated_rc_values_);
         #pragma GCC warning "Handle return"
         sendMessage(msp_rc);
-
-        #pragma GCC warning "Handle return"
-        (void)sendRc();
     }
 
     FcCommsReturns MspFcComms::getBattery(float& voltage)

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -59,6 +59,12 @@ namespace FcComms
         (void)sendRc();
     }
 
+    void MspFcComms::sendArmRequest(const iarc7_msgs::BoolStamped::ConstPtr& message)
+    {
+        // Try to arm, Values over 1800 arm the FC
+        translated_rc_values_[4] = (message->arm_request == true) ? 2000 : 1000;
+    }
+
     // Send the rc commands to the FC using the member array of rc values.
     FcCommsReturns MspFcComms::sendRc()
     {
@@ -66,6 +72,9 @@ namespace FcComms
         msp_rc.packRc(translated_rc_values_);
         #pragma GCC warning "Handle return"
         sendMessage(msp_rc);
+
+        #pragma GCC warning "Handle return"
+        (void)sendRc();
     }
 
     FcCommsReturns MspFcComms::getBattery(float& voltage)

--- a/src/MspFcComms.hpp
+++ b/src/MspFcComms.hpp
@@ -11,6 +11,7 @@
 #include <ros/ros.h>
 #include <string>
 #include "CommonConf.hpp"
+#include "iarc7_msgs/BoolStamped.h"
 #include "iarc7_msgs/Float64Stamped.h"
 #include "iarc7_msgs/OrientationAnglesStamped.h"
 #include "serial/serial.h"
@@ -48,6 +49,7 @@ namespace FcComms
         // Send the flight controller RX values
         void sendFcAngles(const iarc7_msgs::OrientationAnglesStamped::ConstPtr& message);
         void sendFcThrottle(const iarc7_msgs::Float64Stamped::ConstPtr& message);
+        void sendArmRequest(const iarc7_msgs::BoolStamped::ConstPtr& message);
 
     private:
         // Don't allow the copy constructor or assignment.


### PR DESCRIPTION
I considered making this an action however, I feel that this topic should only receive messages from a UI panel for now, if in the future it receives messages from anywhere else, it can be controlled by low level flight.

Low level flight already has to monitor the fc status to know whether it's commands mean anything and the way the fc reports that does not fit well into the overall software design right now.

Build will fail as it needs a new message type.
