### PR TITLE
Create motor test script, fix minor bugs in fc_comms

### DIFF
--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -144,16 +144,16 @@ void CommonFcComms<T>::publishTopics()
     #pragma GCC warning "TODO handle failure"
     flightControlImpl_.getBattery(battery.data);
 
-    ROS_INFO("Autopilot_enabled: %d", fc.auto_pilot);
-    ROS_INFO("Armed: %d", fc.armed);
+    ROS_DEBUG("Autopilot_enabled: %d", fc.auto_pilot);
+    ROS_DEBUG("Armed: %d", fc.armed);
     status_publisher.publish(fc);
-    ROS_INFO("Battery level: %f", battery.data);
+    ROS_DEBUG("Battery level: %f", battery.data);
     battery_publisher.publish(battery);
 
 
     double attitude[3];
     flightControlImpl_.getAttitude(attitude);
-    ROS_INFO("Attitude: %f %f %f", attitude[0], attitude[1], attitude[2]);
+    ROS_DEBUG("Attitude: %f %f %f", attitude[0], attitude[1], attitude[2]);
     sendOrientationTransform(attitude);
 }
 
@@ -161,6 +161,10 @@ void CommonFcComms<T>::publishTopics()
 template<class T>
 void CommonFcComms<T>::updateSensors(const ros::TimerEvent&)
 {
+
+    ros::Time times = ros::Time::now();
+
+
     // Do different things based on the current connection status.
     switch(flightControlImpl_.getConnectionStatus())
     {
@@ -171,10 +175,11 @@ void CommonFcComms<T>::updateSensors(const ros::TimerEvent&)
             break;
         
         case FcCommsStatus::kConnected:
-            ROS_INFO("FC_comms updating FC sensors");
             #pragma GCC warning "TODO handle failure"
             flightControlImpl_.handleComms();
             publishTopics();
+
+            //ROS_WARN("%f to run", (ros::Time::now() - times).toSec());
             break;
 
         case FcCommsStatus::kConnecting:

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -179,7 +179,7 @@ void CommonFcComms<T>::updateSensors(const ros::TimerEvent&)
             flightControlImpl_.handleComms();
             publishTopics();
 
-            //ROS_WARN("%f to run", (ros::Time::now() - times).toSec());
+            ROS_DEBUG("Time to update FC sensors: %f", (ros::Time::now() - times).toSec());
             break;
 
         case FcCommsStatus::kConnecting:

--- a/include/iarc7_fc_comms/MspConf.hpp
+++ b/include/iarc7_fc_comms/MspConf.hpp
@@ -45,7 +45,8 @@ namespace FcComms
         static constexpr const float kMspPitchScale{10.0}; // Should be filled in with values based on (kMspMax-kMspMidpoint) / max_angle
         static constexpr const float kMspRollScale{10.0};  // Should be filled in with values based on (kMspMax-kMspMidpoint) / max_angle
         static constexpr const float kMspYawScale{10.0};   // Should be filled in with values based on (kMspMax-kMspMidpoint) / max_angle
-        static constexpr const float kMspThrottleScale{(2000.0-1000.0) / 100.0};  // (Max-Min)/100 e.g. scale 0% to 100% to min/max throttle
+        static constexpr const float kMspThrottleStartPoint{950.0};
+        static constexpr const float kMspThrottleScale{(2000.0-kMspThrottleStartPoint) / 100.0};  // (Max-Min)/100 e.g. scale 0% to 100% to min/max throttle
 
     };
 

--- a/include/iarc7_fc_comms/MspConf.hpp
+++ b/include/iarc7_fc_comms/MspConf.hpp
@@ -46,7 +46,7 @@ namespace FcComms
         static constexpr const float kMspRollScale{10.0};  // Should be filled in with values based on (kMspMax-kMspMidpoint) / max_angle
         static constexpr const float kMspYawScale{10.0};   // Should be filled in with values based on (kMspMax-kMspMidpoint) / max_angle
         static constexpr const float kMspThrottleStartPoint{950.0};
-        static constexpr const float kMspThrottleScale{(2000.0-kMspThrottleStartPoint) / 100.0};  // (Max-Min)/100 e.g. scale 0% to 100% to min/max throttle
+        static constexpr const float kMspThrottleScale{(2000.0-kMspThrottleStartPoint)};  // (Max-Min) * throttle + min where throttle is ranged from 0-1
 
     };
 

--- a/scripts/motors_test.py
+++ b/scripts/motors_test.py
@@ -27,7 +27,7 @@ if __name__ == '__main__':
         # Three second throttle ramp and three seconds off
         throttle = (throttle + 1) % 150
         if throttle <= 100:
-            command.throttle = float(throttle)
+            command.throttle = float(throttle)/100.0
             command.data.pitch = 0.0
             command.data.roll = 0.0
             command.data.yaw = 0.0

--- a/scripts/motors_test.py
+++ b/scripts/motors_test.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python
+import rospy
+import tf
+
+import math
+
+from iarc7_msgs.msg import OrientationThrottleStamped
+from iarc7_msgs.msg import BoolStamped
+
+from geometry_msgs.msg import TwistStamped
+
+def constrain(x, l, h):
+    return min(h, max(x, l))
+
+if __name__ == '__main__':
+    rospy.init_node('waypoints_test', anonymous=True)
+
+    command_pub = rospy.Publisher('uav_direction_command', OrientationThrottleStamped, queue_size=0)
+    arm_pub = rospy.Publisher('uav_arm', BoolStamped, queue_size=0)
+
+    rate = rospy.Rate(10)
+    throttle = 0
+    while not rospy.is_shutdown():
+        command = OrientationThrottleStamped()
+        command.header.stamp = rospy.Time.now()
+
+        # Three second throttle ramp and three seconds off
+        throttle = (throttle + 1) % 150
+        if throttle <= 100:
+            command.throttle = float(throttle)
+            command.data.pitch = 0.0
+            command.data.roll = 0.0
+            command.data.yaw = 0.0
+            command_pub.publish(command)
+        else:
+            command.throttle = 0.0
+            command.data.pitch = 0.0
+            command.data.roll = 0.0
+            command.data.yaw = 0.0
+            command_pub.publish(command)
+
+        arm = BoolStamped()
+        arm.data = True
+        arm_pub.publish(arm)
+
+        rate.sleep()
+

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -39,14 +39,14 @@ namespace FcComms
         float pitch = (message->data.pitch * FcCommsMspConf::kMspPitchScale) + FcCommsMspConf::kMspMidPoint;
         float yaw   = (message->data.yaw * FcCommsMspConf::kMspRollScale) + FcCommsMspConf::kMspMidPoint;
         float roll  = (message->data.roll * FcCommsMspConf::kMspYawScale) + FcCommsMspConf::kMspMidPoint;
-        float throttle = message->throttle * FcCommsMspConf::kMspThrottleScale;
+        float throttle = message->throttle * FcCommsMspConf::kMspThrottleScale + FcCommsMspConf::kMspThrottleStartPoint;
 
         #pragma GCC warning "Bounds check the floats so we can't send something to big or small"
-        translated_rc_values_[0] = static_cast<uint16_t>(pitch); 
-        //translated_rc_values is initialized in the corresponding .hpp file
-        translated_rc_values_[1] = static_cast<uint16_t>(yaw);
-        translated_rc_values_[2] = static_cast<uint16_t>(roll);
-        translated_rc_values_[3] = static_cast<uint16_t>(throttle);
+        translated_rc_values_[0] = static_cast<uint16_t>(roll);
+        translated_rc_values_[1] = static_cast<uint16_t>(pitch); 
+        translated_rc_values_[2] = static_cast<uint16_t>(throttle);
+        translated_rc_values_[3] = static_cast<uint16_t>(yaw);
+        ROS_INFO("THROTTLE: %f", throttle);
 
         #pragma GCC warning "Handle return"
         (void)sendRc();
@@ -63,19 +63,12 @@ namespace FcComms
     // Send the rc commands to the FC using the member array of rc values.
     FcCommsReturns MspFcComms::getRawRC(uint16_t (&rc_values)[18]) 
     {
-        char RC_info[200];
         MSP_RC msp_getrawRC;
-        sendMessage(msp_getrawRC);
-        
+        sendMessage(msp_getrawRC);        
         msp_getrawRC.getRc(rc_values); 
-
-
-        uint32_t j{0};
-        j+=sprintf(RC_info, "Raw Rc: %d", rc_values[0]);
-
-        //Look at getstatus for a todo regarding ROS::debug
     }
 
+    // Debug function to print the raw rc values, not called from anywhere but can be used for debugging
     void MspFcComms::printRawRC()
     {
         uint16_t raw_values[18];
@@ -264,9 +257,6 @@ namespace FcComms
 
     FcCommsReturns MspFcComms::handleComms()
     {   
-        //print the raw RC
-        printRawRC();
-
         // Check Connection
         // Check that the serial port is still open.
         if(fc_serial_->isOpen() == false)


### PR DESCRIPTION
Don't print out unnecessary logs to terminal, direct them to debug
Fix throttle calculation with an accurate startpoint
Fix order of packing uav stick position messages

General throttle test driver, this is the initial structure. It will be expanded to take command line arguments to test, yaw, pitch, roll, and other functionality such as disarming.