### PR TITLE
Set packet priority

### DIFF
--- a/include/iarc7_fc_comms/CommonConf.hpp
+++ b/include/iarc7_fc_comms/CommonConf.hpp
@@ -27,8 +27,7 @@ enum class FcCommsStatus
 
 struct CommonConf
 {
-    // In seconds.
-    static constexpr const float kFcSensorsUpdateRateHz{5};
+    static constexpr const float kFcSensorsUpdateRateHz{30};
 
     static constexpr const double kMinAllowedRoll = -0.25;
     static constexpr const double kMaxAllowedRoll = 0.25;

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -54,8 +54,11 @@ namespace FcComms{
         // Update information from flight controller and send information
         void update();
 
-        // Update flight controller status information
-        void updateFcStatus();
+        // Update flight controller armed information
+        void updateArmed();
+
+        // Update flight controller auto pilot enabled information
+        void updateAutoPilotEnabled();
 
         // Update flight controller battery information
         void updateBattery();
@@ -114,7 +117,8 @@ namespace FcComms{
 
         typedef void (CommonFcComms::*CommonFcCommsMemFn)();
 
-        CommonFcCommsMemFn sequenced_updates[2] = {&CommonFcComms::updateFcStatus,
+        CommonFcCommsMemFn sequenced_updates[3] = {&CommonFcComms::updateArmed,
+                                                   &CommonFcComms::updateAutoPilotEnabled,
                                                    &CommonFcComms::updateBattery
                                                   };
 
@@ -213,26 +217,33 @@ FcCommsReturns CommonFcComms<T>::run()
     return flightControlImpl_.disconnect();
 }
 
-// Update flight controller status information
+// Update flight controller arming information
 template<class T>
-void CommonFcComms<T>::updateFcStatus()
+void CommonFcComms<T>::updateArmed()
 {
-    iarc7_msgs::FlightControllerStatus fc;
     bool temp_armed;
-    bool temp_auto_pilot;
-    bool temp_failsafe;
-    FcCommsReturns status = flightControlImpl_.getStatus(temp_armed, temp_auto_pilot, temp_failsafe);
+    FcCommsReturns status = flightControlImpl_.isArmed(temp_armed);
     if (status != FcCommsReturns::kReturnOk) {
         ROS_ERROR("Failed to retrieve flight controller status");
     }
     else
     {
-        fc.armed = temp_armed;
-        fc.auto_pilot = temp_auto_pilot;
-        fc.failsafe = temp_failsafe;
-        ROS_DEBUG("Autopilot_enabled: %d", fc.auto_pilot);
-        ROS_DEBUG("Armed: %d", fc.armed);
-        status_publisher.publish(fc);
+        ROS_DEBUG("Armed: %d", temp_armed);
+    }
+}
+
+// Update flight controller auto pilot status information
+template<class T>
+void CommonFcComms<T>::updateAutoPilotEnabled()
+{
+    bool temp_auto_pilot;
+    FcCommsReturns status = flightControlImpl_.isAutoPilotAllowed(temp_auto_pilot);
+    if (status != FcCommsReturns::kReturnOk) {
+        ROS_ERROR("Failed to retrieve flight controller status");
+    }
+    else
+    {
+        ROS_DEBUG("Autopilot_enabled: %d", temp_auto_pilot);
     }
 }
 

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -40,9 +40,17 @@ namespace FcComms
         FcCommsReturns  __attribute__((warn_unused_result))
             handleComms();
 
-        // Get the flight status of the FC.
+        // Find out if the FC is armed.
         FcCommsReturns  __attribute__((warn_unused_result))
-            getStatus(bool& armed, bool& auto_pilot, bool& failsafe);
+            isArmed(bool& armed);
+
+        // Find out if the FC is in failsafe
+        FcCommsReturns  __attribute__((warn_unused_result))
+            isFailsafe(bool& failsafe);
+
+        // Find out if the FC has enabled auto_pilot
+        FcCommsReturns  __attribute__((warn_unused_result))
+            isAutoEnabled(bool& auto_pilot);
 
         // Get the battery voltage of the FC.
         FcCommsReturns  __attribute__((warn_unused_result))

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -174,7 +174,7 @@ FcCommsReturns MspFcComms::getBattery(float& voltage)
     return status;
 }
 
-FcCommsReturns MspFcComms::getStatus(bool& armed, bool& auto_pilot, bool& failsafe)
+FcCommsReturns MspFcComms::isArmed(bool& armed)
 {
     // Adding the autopilot flag is probably going to require modifying the FC firmware
     // And could be quite a bit of work.
@@ -183,13 +183,7 @@ FcCommsReturns MspFcComms::getStatus(bool& armed, bool& auto_pilot, bool& failsa
 
     if (return_status == FcCommsReturns::kReturnOk) {
         armed = status.getArmed();
-
-        MSP_RC rc_channels;
-        return_status = isAutoPilotAllowed(auto_pilot);
     }
-
-    // TODO Finish implementing autopilot and failsafe
-    failsafe = false;
 
     return return_status;
 }


### PR DESCRIPTION
MSP packets can be sent at 100hz.

Decided to set 30hz update rate.

Every update 2 packets are always sent. Stick positions and the attitude is updated.

A third packet is also sent. The third packet to be sent is picked round robin style from a list. The list currently contains, finding the arming status, whether auto pilot is enabled, and getting the battery level.