### PR TITLE
Make arming a service, establish order to send MSP packets.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,8 @@ set(CMAKE_CXX_FLAGS "-Wall -Wextra -Werror ${CMAKE_CXX_FLAGS}")
 ## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
   iarc7_msgs
+  std_msgs
+  std_srvs
   roscpp
   message_generation
   serial

--- a/include/iarc7_fc_comms/CommonConf.hpp
+++ b/include/iarc7_fc_comms/CommonConf.hpp
@@ -27,8 +27,7 @@ enum class FcCommsStatus
 
 struct CommonConf
 {
-    // In seconds.
-    static constexpr const float kFcSensorsUpdateRateHz{5};
+    static constexpr const float kFcSensorsUpdateRateHz{30};
 
     static constexpr const double kMinAllowedRoll = -0.25;
     static constexpr const double kMaxAllowedRoll = 0.25;

--- a/include/iarc7_fc_comms/CommonConf.hpp
+++ b/include/iarc7_fc_comms/CommonConf.hpp
@@ -29,6 +29,10 @@ struct CommonConf
 {
     static constexpr const float kFcSensorsUpdateRateHz{30};
 
+    // This needs to take less time than the monitor bonds need to update
+    // since they will break if this is too long and arming fails.
+    static constexpr const double kMaxArmDelay{0.2};
+
     static constexpr const double kMinAllowedRoll = -0.25;
     static constexpr const double kMaxAllowedRoll = 0.25;
     static constexpr const double kMinAllowedPitch = -0.25;

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -239,6 +239,7 @@ bool CommonFcComms<T>::uavArmServiceHandler(
     // If auto pilot is not enabled we have no power
     if(!auto_pilot)
     {
+        ROS_INFO("Failed to arm or disarm the FC: auto pilot is disabled");
         response.success = false;
         response.message = "disabled";
         return true;
@@ -263,15 +264,15 @@ bool CommonFcComms<T>::uavArmServiceHandler(
             return false;
         }
 
-        if(armed)
+        if(armed == request.data)
         {
-            ROS_INFO("FC is armed");
+            ROS_INFO("FC arm or disarm set succesfully");
             response.success = true;
             return true;
         }
     }
 
-    ROS_INFO("Failed to arm FC");
+    ROS_INFO("Failed to arm or disarm the FC: timeout out");
     response.success = false;
     response.message = "timed out";
     return true;

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -54,8 +54,11 @@ namespace FcComms{
         // Update information from flight controller and send information
         void update();
 
-        // Update flight controller status information
-        void updateFcStatus();
+        // Update flight controller armed information
+        void updateArmed();
+
+        // Update flight controller auto pilot enabled information
+        void updateAutoPilotEnabled();
 
         // Update flight controller battery information
         void updateBattery();
@@ -114,7 +117,8 @@ namespace FcComms{
 
         typedef void (CommonFcComms::*CommonFcCommsMemFn)();
 
-        CommonFcCommsMemFn sequenced_updates[2] = {&CommonFcComms::updateFcStatus,
+        CommonFcCommsMemFn sequenced_updates[3] = {&CommonFcComms::updateArmed,
+                                                   &CommonFcComms::updateAutoPilotEnabled,
                                                    &CommonFcComms::updateBattery
                                                   };
 
@@ -213,26 +217,33 @@ FcCommsReturns CommonFcComms<T>::run()
     return flightControlImpl_.disconnect();
 }
 
-// Update flight controller status information
+// Update flight controller arming information
 template<class T>
-void CommonFcComms<T>::updateFcStatus()
+void CommonFcComms<T>::updateArmed()
 {
-    iarc7_msgs::FlightControllerStatus fc;
     bool temp_armed;
-    bool temp_auto_pilot;
-    bool temp_failsafe;
-    FcCommsReturns status = flightControlImpl_.getStatus(temp_armed, temp_auto_pilot, temp_failsafe);
+    FcCommsReturns status = flightControlImpl_.isArmed(temp_armed);
     if (status != FcCommsReturns::kReturnOk) {
         ROS_ERROR("Failed to retrieve flight controller status");
     }
     else
     {
-        fc.armed = temp_armed;
-        fc.auto_pilot = temp_auto_pilot;
-        fc.failsafe = temp_failsafe;
-        ROS_DEBUG("Autopilot_enabled: %d", fc.auto_pilot);
-        ROS_DEBUG("Armed: %d", fc.armed);
-        status_publisher.publish(fc);
+        ROS_DEBUG("Armed: %d", temp_armed);
+    }
+}
+
+// Update flight controller auto pilot status information
+template<class T>
+void CommonFcComms<T>::updateAutoPilotEnabled()
+{
+    bool temp_auto_pilot;
+    FcCommsReturns status = flightControlImpl_.isAutoPilotAllowed(temp_auto_pilot);
+    if (status != FcCommsReturns::kReturnOk) {
+        ROS_ERROR("Failed to retrieve flight controller status");
+    }
+    else
+    {
+        ROS_DEBUG("Autopilot_enabled: %d", temp_auto_pilot);
     }
 }
 

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -166,6 +166,14 @@ CommonFcComms<T>& CommonFcComms<T>::getInstance()
 template<class T>
 FcCommsReturns CommonFcComms<T>::init()
 {
+    uav_arm_service = nh_.advertiseService("uav_arm",
+                                       &CommonFcComms::uavArmServiceHandler,
+                                       this);
+    if (!uav_arm_service) {
+        ROS_ERROR("CommonFcComms failed to create arming service");
+        return FcCommsReturns::kReturnError;
+    }
+
     ROS_ASSERT_MSG(safety_client_.formBond(), "fc_comms_msp: Could not form bond with safety client");
 
     battery_publisher = nh_.advertise<std_msgs::Float32>("fc_battery", 50);
@@ -187,14 +195,6 @@ FcCommsReturns CommonFcComms<T>::init()
                                          this);
     if (!uav_angle_subscriber) {
         ROS_ERROR("CommonFcComms failed to create angle subscriber");
-        return FcCommsReturns::kReturnError;
-    }
-
-    uav_arm_service = nh_.advertiseService("uav_arm",
-                                       &CommonFcComms::uavArmServiceHandler,
-                                       this);
-    if (!uav_arm_service) {
-        ROS_ERROR("CommonFcComms failed to create arming service");
         return FcCommsReturns::kReturnError;
     }
 

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -258,15 +258,17 @@ bool CommonFcComms<T>::uavArmServiceHandler(
     {
         bool armed;
         FcCommsReturns status = flightControlImpl_.isArmed(armed);
-        if (status != FcCommsReturns::kReturnOk) {
-            ROS_ERROR("Failed to retrieve flight controller arm status");
+        if (status == FcCommsReturns::kReturnOk) {
+            if(armed == request.data)
+            {
+                ROS_INFO("FC arm or disarm set succesfully");
+                response.success = true;
+                return true;
+            }
         }
-
-        if(armed == request.data)
+        else
         {
-            ROS_INFO("FC arm or disarm set succesfully");
-            response.success = true;
-            return true;
+            ROS_ERROR("Failed to retrieve flight controller arm status");     
         }
     }
 

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -148,8 +148,7 @@ uav_throttle_subscriber(),
 uav_arm_service(),
 last_direction_command_message_ptr_()
 {
-    //sequenced_updates[0] = this->updateFcStatus;
-    //sequenced_updates[1] = this->updateFcStatus;
+
 }
 
 template<class T>
@@ -261,7 +260,6 @@ bool CommonFcComms<T>::uavArmServiceHandler(
         FcCommsReturns status = flightControlImpl_.isArmed(armed);
         if (status != FcCommsReturns::kReturnOk) {
             ROS_ERROR("Failed to retrieve flight controller arm status");
-            return false;
         }
 
         if(armed == request.data)

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -341,7 +341,7 @@ void CommonFcComms<T>::updateAttitude()
     }
 }
 
-// Send arm and direction message to flight controller
+// Send direction message to flight controller
 template<class T>
 void CommonFcComms<T>::updateDirection()
 {
@@ -434,10 +434,10 @@ void CommonFcComms<T>::update()
                 updateAttitude();
             }
 
-            publishFcStatus();
-
             (this->*sequenced_updates[current_sequenced_update])();
             current_sequenced_update = (current_sequenced_update + 1) % num_sequenced_updates;
+
+            publishFcStatus();
 
             ROS_DEBUG("iarc7_fc_comms: Time to update FC sensors: %f", (ros::Time::now() - times).toSec());
             break;

--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -321,7 +321,7 @@ void CommonFcComms<T>::updateAttitude()
 
 // Send arm and direction message to flight controller
 template<class T>
-void CommonFcComms<T>::updateArmDirection()
+void CommonFcComms<T>::updateDirection()
 {
     FcCommsReturns status{FcCommsReturns::kReturnOk};
 
@@ -431,12 +431,12 @@ void CommonFcComms<T>::update()
 template<class T>
 void CommonFcComms<T>::publishFcStatus()
 {
-    iarc7_msgs::FlightControllerStatus status_publisher
+    iarc7_msgs::FlightControllerStatus status_message;
 
-    status_publisher.armed = fc_armed_;
-    status_publisher.failsafe = fc_failsafe_;
+    status_message.armed = fc_armed_;
+    status_message.failsafe = fc_failsafe_;
 
-    status_publisher.publish(status_publisher);
+    status_publisher.publish(status_message);
 }
 
 // Send out the transform for the level_quad to quad

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -40,9 +40,17 @@ namespace FcComms
         FcCommsReturns  __attribute__((warn_unused_result))
             handleComms();
 
-        // Get the flight status of the FC.
+        // Find out if the FC is armed.
         FcCommsReturns  __attribute__((warn_unused_result))
-            getStatus(bool& armed, bool& auto_pilot, bool& failsafe);
+            isArmed(bool& armed);
+
+        // Find out if the FC is in failsafe
+        FcCommsReturns  __attribute__((warn_unused_result))
+            isFailsafe(bool& failsafe);
+
+        // Find out if the FC has enabled auto_pilot
+        FcCommsReturns  __attribute__((warn_unused_result))
+            isAutoEnabled(bool& auto_pilot);
 
         // Get the battery voltage of the FC.
         FcCommsReturns  __attribute__((warn_unused_result))

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -71,8 +71,7 @@ namespace FcComms
             processDirectionCommandMessage(
                 const iarc7_msgs::OrientationThrottleStamped::ConstPtr& message);
         FcCommsReturns  __attribute__((warn_unused_result))
-            processArmMessage(
-                const iarc7_msgs::BoolStamped::ConstPtr& message);
+            setArm(bool arm);
 
         FcCommsReturns  __attribute__((warn_unused_result))
             printRawRC();

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -48,10 +48,6 @@ namespace FcComms
         FcCommsReturns  __attribute__((warn_unused_result))
             isFailsafe(bool& failsafe);
 
-        // Find out if the FC has enabled auto_pilot
-        FcCommsReturns  __attribute__((warn_unused_result))
-            isAutoEnabled(bool& auto_pilot);
-
         // Get the battery voltage of the FC.
         FcCommsReturns  __attribute__((warn_unused_result))
             getBattery(float& voltage);

--- a/launch/fc_comms_msp.launch
+++ b/launch/fc_comms_msp.launch
@@ -1,3 +1,3 @@
 <launch>
-    <node name="fc_comms_msp" pkg="iarc7_fc_comms" type="fc_comms_msp"/>
+    <node name="fc_comms_msp" pkg="iarc7_fc_comms" type="fc_comms_msp" output="screen"/>
 </launch>

--- a/launch/fc_comms_msp.launch
+++ b/launch/fc_comms_msp.launch
@@ -1,3 +1,3 @@
 <launch>
-    <node name="fc_comms_msp" pkg="iarc7_fc_comms" type="fc_comms_msp" output="screen"/>
+    <node name="fc_comms_msp" pkg="iarc7_fc_comms" type="fc_comms_msp"/>
 </launch>

--- a/package.xml
+++ b/package.xml
@@ -44,12 +44,14 @@
   <build_depend>roscpp</build_depend>
   <build_depend>rosconsole</build_depend>
   <build_depend>std_msgs</build_depend>
+  <build_depend>std_srvs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>serial</build_depend>
   <build_depend>tf2</build_depend>
   <build_depend>tf2_ros</build_depend>
   <build_depend>iarc7_safety</build_depend>
   <run_depend>iarc7_msgs</run_depend>
+  <run_depend>std_srvs</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>tf2</run_depend>
   <run_depend>tf2_ros</run_depend>

--- a/scripts/motors_test.py
+++ b/scripts/motors_test.py
@@ -16,6 +16,9 @@ from geometry_msgs.msg import TwistStamped
 if __name__ == '__main__':
     rospy.init_node('waypoints_test', anonymous=True)
 
+    rospy.wait_for_service('uav_arm')
+    arm_service = rospy.ServiceProxy('uav_arm', SetBool)
+
     safety_client = SafetyClient('motors_test')
     safety_client.form_bond()
 
@@ -24,7 +27,6 @@ if __name__ == '__main__':
 
     armed = False
     while armed == False :
-        arm_service = rospy.ServiceProxy('uav_arm', SetBool)
         try:
             armed = arm_service(True)
         except rospy.ServiceException as exc:

--- a/scripts/motors_test.py
+++ b/scripts/motors_test.py
@@ -9,11 +9,9 @@ from iarc7_safety.SafetyClient import SafetyClient
 from iarc7_msgs.msg import OrientationThrottleStamped
 from iarc7_msgs.msg import BoolStamped
 
+from std_srvs.srv import SetBool
+
 from geometry_msgs.msg import TwistStamped
-
-
-def constrain(x, l, h):
-    return min(h, max(x, l))
 
 if __name__ == '__main__':
     rospy.init_node('waypoints_test', anonymous=True)
@@ -24,7 +22,15 @@ if __name__ == '__main__':
     command_pub = rospy.Publisher('uav_direction_command', OrientationThrottleStamped, queue_size=0)
     arm_pub = rospy.Publisher('uav_arm', BoolStamped, queue_size=0)
 
-    rate = rospy.Rate(10)
+    armed = False
+    while armed == False :
+        arm_service = rospy.ServiceProxy('uav_arm', SetBool)
+        try:
+            armed = arm_service(True)
+        except rospy.ServiceException as exc:
+            print("Could not arm: " + str(exc))
+
+    rate = rospy.Rate(30)
     throttle = 0
     while not rospy.is_shutdown():
 

--- a/scripts/motors_test.py
+++ b/scripts/motors_test.py
@@ -23,7 +23,6 @@ if __name__ == '__main__':
     safety_client.form_bond()
 
     command_pub = rospy.Publisher('uav_direction_command', OrientationThrottleStamped, queue_size=0)
-    arm_pub = rospy.Publisher('uav_arm', BoolStamped, queue_size=0)
 
     armed = False
     while armed == False :

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -174,7 +174,7 @@ FcCommsReturns MspFcComms::getBattery(float& voltage)
     return status;
 }
 
-FcCommsReturns MspFcComms::getStatus(bool& armed, bool& auto_pilot, bool& failsafe)
+FcCommsReturns MspFcComms::isArmed(bool& armed)
 {
     // Adding the autopilot flag is probably going to require modifying the FC firmware
     // And could be quite a bit of work.
@@ -183,13 +183,7 @@ FcCommsReturns MspFcComms::getStatus(bool& armed, bool& auto_pilot, bool& failsa
 
     if (return_status == FcCommsReturns::kReturnOk) {
         armed = status.getArmed();
-
-        MSP_RC rc_channels;
-        return_status = isAutoPilotAllowed(auto_pilot);
     }
-
-    // TODO Finish implementing autopilot and failsafe
-    failsafe = false;
 
     return return_status;
 }

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -96,11 +96,10 @@ FcCommsReturns MspFcComms::processDirectionCommandMessage(
     return sendRc();
 }
 
-FcCommsReturns MspFcComms::processArmMessage(
-      const iarc7_msgs::BoolStamped::ConstPtr& message)
+FcCommsReturns MspFcComms::setArm(bool arm)
 {
     // Try to arm, Values over 1800 arm the FC
-    translated_rc_values_[4] = (message->data == true) ? 2000 : 1000;
+    translated_rc_values_[4] = (arm == true) ? 2000 : 1000;
     return sendRc();
 }
 


### PR DESCRIPTION
MSP packets can be sent at 100hz.

Updates run at 30hz. Stick positions and orientation updates are performed every time. A third packet is sent from a list of lower priority packets. Currently that list only holds functions to find out if the flight controller is armed, auto pilot is enabled, and check the battery level.

Additionally to arm requests are now responded to with a service. The service checks to see if auto pilot is enabled and then attempts to arm. It waits for a certain amount of time, checking to see if the FC armed before returning success or failure.

This still needs to be test on real hardware.