### PR TITLE
Removed requirement of gcc-snapshot from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
   - sudo apt-get install -y build-essential software-properties-common
   - sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
   - sudo apt-get update
-  - sudo apt-get install -y gcc-snapshot gcc-6 g++-6
+  - sudo apt-get install -y gcc-6 g++-6
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 60 --slave /usr/bin/g++ g++ /usr/bin/g++-6
   - sudo apt-get install -y gcc-4.8 g++-4.8
   - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-4.8 60 --slave /usr/bin/g++ g++ /usr/bin/g++-4.8


### PR DESCRIPTION
This shaves about 40s off our build time