### PR TITLE
Get fc accelerations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,7 @@ find_package(catkin REQUIRED COMPONENTS
   tf2
   tf2_ros
   iarc7_safety
+  sensor_msgs
 )
 
 ## System dependencies are found with CMake's conventions

--- a/include/iarc7_fc_comms/CommonConf.hpp
+++ b/include/iarc7_fc_comms/CommonConf.hpp
@@ -27,7 +27,7 @@ enum class FcCommsStatus
 
 struct CommonConf
 {
-    static constexpr const float kFcSensorsUpdateRateHz{30};
+    static constexpr const float kFcSensorsUpdateRateHz{100};
 
     static constexpr const double kMaxArmDelay = 0.1;
 

--- a/include/iarc7_fc_comms/MspCommands.hpp
+++ b/include/iarc7_fc_comms/MspCommands.hpp
@@ -235,6 +235,9 @@ namespace FcComms
                 // which has an mpu6500 in it
                 // In cleanflight accgyro_mpu6500.c in function mpu6500AccInit
                 // The scale for 1g of acceleration for is set to 512 * 8
+                // We are also using a hacked up version of cleanflight that does not
+                // apply this scaling factor using a bitshift hack before sending so
+                // we need to do it here.
                 acc_values[i] = static_cast<double>(*temp)/(512.0 * 8.0);
             }
         }

--- a/include/iarc7_fc_comms/MspCommands.hpp
+++ b/include/iarc7_fc_comms/MspCommands.hpp
@@ -196,6 +196,49 @@ namespace FcComms
             attitude_values[2] = attitude_values[2] * M_PI / 180.0;
         }
     };
+
+    struct MSP_RAW_IMU
+    {
+        // Default constructor an destructor
+        MSP_RAW_IMU() = default;
+        ~MSP_RAW_IMU() = default;
+
+        // Don't allow the copy constructor or assignment.
+        MSP_RAW_IMU(const MSP_RAW_IMU& rhs) = delete;
+        MSP_RAW_IMU& operator=(const MSP_RAW_IMU& rhs) = delete;
+
+        static const uint8_t message_id{102};
+        static const uint8_t data_length{0};
+
+        static constexpr char const * const string_name{"MSP_RAW_IMU"};
+
+        uint8_t send[FcCommsMspConf::kMspMaxDataLength]={};
+
+        uint8_t response[FcCommsMspConf::kMspMaxDataLength];
+
+        // Returns the IMU values
+        void getAcc(double (&acc_values)[3])
+        {
+            // Jetson runs in little endian mode and the FC
+            // Receives data in big endian
+            // Jetson sends back 9 IMU data integers. 16bits each.
+            for(uint32_t i = 0; i < 3; i++)
+            {
+                // Unpack the value
+                uint16_t unpacked_value = response[i*2] | (response[(i*2)+1] << 8);
+
+                // Reinterpret as signed
+                int16_t* temp = reinterpret_cast<int16_t*>(&unpacked_value);
+
+                // Convert to doubles
+                // IARC 2016-2017 is using an spf3 evo, which has an MPU9250,
+                // which has an mpu6500 in it
+                // In cleanflight accgyro_mpu6500.c in function mpu6500AccInit
+                // The scale for 1g of acceleration for is set to 512 * 8
+                acc_values[i] = static_cast<double>(*temp)/(512.0 * 8.0);
+            }
+        }
+    };
 }
 
 #endif

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -73,6 +73,9 @@ namespace FcComms
             printRawRC();
 
         FcCommsReturns  __attribute__((warn_unused_result))
+            getAccelerations(double (&accelerations)[3]);
+
+        FcCommsReturns  __attribute__((warn_unused_result))
             isAutoPilotAllowed(bool& allowed);
 
         FcCommsReturns  __attribute__((warn_unused_result))

--- a/package.xml
+++ b/package.xml
@@ -45,6 +45,7 @@
   <build_depend>rosconsole</build_depend>
   <build_depend>std_msgs</build_depend>
   <build_depend>std_srvs</build_depend>
+  <build_depend>sensor_msgs</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>serial</build_depend>
   <build_depend>tf2</build_depend>

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -132,6 +132,16 @@ FcCommsReturns MspFcComms::printRawRC()
     return status;
 }
 
+FcCommsReturns MspFcComms::getAccelerations(double (&accelerations)[3])
+{
+    MSP_RAW_IMU msp_imu;
+    FcCommsReturns status = sendMessage(msp_imu);
+    if (status == FcCommsReturns::kReturnOk) {
+        msp_imu.getAcc(accelerations);
+    }
+    return status;
+}
+
 FcCommsReturns MspFcComms::isAutoPilotAllowed(bool& allowed)
 {
     uint16_t autoRCvalues[FcCommsMspConf::kMspReceivableChannels];

--- a/src/MspSpeedTest.cpp
+++ b/src/MspSpeedTest.cpp
@@ -78,6 +78,22 @@ int main(int argc, char **argv)
         delta = ros::Time::now() - start_time;
         ROS_INFO("Direction/attitude packet rate: %f hz", 200.0/delta.toSec());
         ros::spinOnce();
+
+        start_time = ros::Time::now();
+        for(int i = 0; i < 100; i++)
+        {
+            double accelerations[3];
+            status = comms.getAccelerations(accelerations);
+
+            if(status != FcCommsReturns::kReturnOk)
+            {
+                ROS_ASSERT_MSG(false, "Error sending get acceleration packet");
+            }
+        }
+
+        delta = ros::Time::now() - start_time;
+        ROS_INFO("Acceleration packet rate: %f hz", 100.0/delta.toSec());
+        ros::spinOnce();
     }
 
     status = comms.disconnect();


### PR DESCRIPTION
Also's raises the general purpose update rate to 100hz since our version of cleanflight now accepts 1000 packets a second.

Still doing round robin dispatching on non-essential packets. (Their update rate is up too though)