### PR TITLE
Remove flight controller mode switching

### DIFF
--- a/include/iarc7_fc_comms/CommonFcComms.hpp
+++ b/include/iarc7_fc_comms/CommonFcComms.hpp
@@ -364,9 +364,7 @@ bool CommonFcComms<T>::uavArmServiceHandler(
             {
                 ROS_INFO("FC arm or disarm set succesfully");
 
-                status = flightControlImpl_.postArm(request.data,
-                                                    request.set_mode,
-                                                    request.angle);
+                status = flightControlImpl_.postArm(request.data);
                 if(status != FcCommsReturns::kReturnOk) {
                     ROS_ERROR("iarc7_fc_comms: Post arm action failed");
                     return false;

--- a/include/iarc7_fc_comms/MspFcComms.hpp
+++ b/include/iarc7_fc_comms/MspFcComms.hpp
@@ -46,7 +46,7 @@ namespace FcComms
 
         // Perform any post arming actions
         FcCommsReturns  __attribute__((warn_unused_result))
-            postArm(bool arm, bool set_mode, bool angle);
+            postArm(bool arm);
 
         // Calibrate the accelerometer
         FcCommsReturns  __attribute__((warn_unused_result))

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -185,6 +185,9 @@ FcCommsReturns MspFcComms::isAutoPilotAllowed(bool& allowed)
 FcCommsReturns MspFcComms::sendRc()
 {
     MSP_SET_RAW_RC msp_rc;
+
+    // Make sure we are in angle mode
+    translated_rc_values_[5] = FcCommsMspConf::kMspStickEndPoint;
     msp_rc.packRc(translated_rc_values_);
     return sendMessage(msp_rc);
 }

--- a/src/MspFcComms.cpp
+++ b/src/MspFcComms.cpp
@@ -107,20 +107,13 @@ FcCommsReturns MspFcComms::setArm(bool arm)
     return sendRc();
 }
 
-FcCommsReturns MspFcComms::postArm(bool arm, bool set_mode, bool angle)
+FcCommsReturns MspFcComms::postArm(bool arm)
 {
-    // Set flight mode
-    if (set_mode) {
-        translated_rc_values_[5] = angle ?
-            FcCommsMspConf::kMspStickEndPoint :
-            FcCommsMspConf::kMspStickStartPoint;
-    }
-
     // Set the throttle to the min throttle or off
     uint16_t min_throttle = CommonConf::kMinAllowedThrottle
                             * FcCommsMspConf::kMspThrottleScale
                             + FcCommsMspConf::kMspStickStartPoint;
-    translated_rc_values_[2] = (arm == true) ?
+    translated_rc_values_[2] = arm ?
         min_throttle : FcCommsMspConf::kMspStickStartPoint;
 
     return sendRc();


### PR DESCRIPTION
Remove flight controller mode switching as it is no longer needed.

Do not merge until Evan's switch checking PR's are done.

@MiscM This branch should be on the drone when you are performing your testing